### PR TITLE
modified reporting missing artifact in one root artifact for show path.

### DIFF
--- a/src/main/java/org/jboss/wolf/validator/impl/SurefireXmlReporter.java
+++ b/src/main/java/org/jboss/wolf/validator/impl/SurefireXmlReporter.java
@@ -111,8 +111,9 @@ public class SurefireXmlReporter implements Reporter {
         for (Artifact artifact : sortArtifacts(artifactNotFoundMap.keySet())) {
             List<DependencyNode> roots = sortDependencyNodes(artifactNotFoundMap.get(artifact));
             if (roots.size() == 1) {
-                String msg = "Miss " + artifact + " in " + roots.get(0).getArtifact() + " (path " + findPathToDependency(artifact, roots.get(0)) + ")";
-                reportTestCase(type, reportEntryType, msg, null, testSuite);
+                String path = "path " + findPathToDependency(artifact, roots.get(0));
+                String msg = "Miss " + artifact + " in " + roots.get(0).getArtifact() + " (" + path + ")";
+                reportTestCase(type, reportEntryType, msg, path, testSuite);
             } else {
                 String msg = "Miss " + artifact + " in " + roots.size() + " artifacts ...";
                 StringBuilder dsc = new StringBuilder();

--- a/src/test/java/org/jboss/wolf/validator/impl/TestSurefireXmlReporter.java
+++ b/src/test/java/org/jboss/wolf/validator/impl/TestSurefireXmlReporter.java
@@ -214,9 +214,9 @@ public class TestSurefireXmlReporter {
 
         String depNotFoundReportContent = FileUtils.readFileToString(depNotFoundReportFile);
         assertTrue(depNotFoundReportContent.contains("<testcase name=\"__Miss org:missing:jar:1.0 in org:validated2-not-filtered:pom:1.1 \"" +
-                " classname=\"DependencyNotFoundReport\" time=\"0\">\n    <error type=\"\"></error>"));
+                " classname=\"DependencyNotFoundReport\" time=\"0\">\n    <error type=\"path org\">path org:validated2-not-filtered:pom:1.1</error>"));
         assertTrue(depNotFoundReportContent.contains("<testcase name=\"__Miss org:missing:jar:1.0 in org:validated:pom:1.0 \"" +
-                " classname=\"DependencyNotFoundReport\" time=\"0\">\n    <skipped type=\"\"></skipped>"));
+                " classname=\"DependencyNotFoundReport\" time=\"0\">\n    <skipped type=\"path org\">path org:validated:pom:1.0</skipped>"));
     }
 
     @Test
@@ -248,9 +248,9 @@ public class TestSurefireXmlReporter {
 
         String depNotFoundReportContent = FileUtils.readFileToString(depNotFoundReportFile);
         assertTrue(depNotFoundReportContent.contains("<testcase name=\"__Miss org:missing:jar:1.0 in org:validated2-not-filtered:pom:1.1 \"" +
-                " classname=\"BomDependencyNotFoundReport\" time=\"0\">\n    <error type=\"\"></error>"));
+                " classname=\"BomDependencyNotFoundReport\" time=\"0\">\n    <error type=\"path org\">path org:validated2-not-filtered:pom:1.1</error>"));
         assertTrue(depNotFoundReportContent.contains("<testcase name=\"__Miss org:missing:jar:1.0 in org:validated:pom:1.0 \"" +
-                " classname=\"BomDependencyNotFoundReport\" time=\"0\">\n    <skipped type=\"\"></skipped>"));
+                " classname=\"BomDependencyNotFoundReport\" time=\"0\">\n    <skipped type=\"path org\">path org:validated:pom:1.0</skipped>"));
     }
 
     @Test


### PR DESCRIPTION
I don't know why, but path has been cut off from testcase name:
  <testcase name="__Miss args4j:args4j-site:jar:2.0.12-redhat-2 in org.drools:drools-bom:pom:6.0.0-redhat-9 " classname="BomDependencyNotFoundReport" time="0">
    <error type=""/></error>
  </testcase>
 
So I added path to the error description too:
  <testcase name="__Miss args4j:args4j-site:jar:2.0.12-redhat-2 in org.drools:drools-bom:pom:6.0.0-redhat-9 " classname="BomDependencyNotFoundReport" time="0">
    <error type="path org.drools">path org.drools:drools-bom:pom:6.0.0-redhat-9 > args4j:args4j-site:jar:2.0.12-redhat-2</error>
  </testcase>
